### PR TITLE
fontawesome5のCDN設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,10 +73,3 @@ gem 'devise'
 gem "haml-rails", "~> 1.0"
 gem 'kaminari'
 gem "font-awesome-rails"
-gem 'font-awesome-sass', '~> 5.6.1'
-gem 'font_awesome5_rails'
-
-
-
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,13 +102,9 @@ GEM
     erubi (1.8.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    ffi (1.9.25)
+    ffi (1.10.0)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
-    font-awesome-sass (5.6.1)
-      sassc (>= 1.11)
-    font_awesome5_rails (0.4.3)
-      railties (>= 4.2, < 5.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -228,9 +224,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.0)
-      ffi (~> 1.9.6)
-      rake
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -293,8 +286,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   font-awesome-rails
-  font-awesome-sass (~> 5.6.1)
-  font_awesome5_rails
   haml-rails (~> 1.0)
   jbuilder (~> 2.5)
   kaminari

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,5 +7,6 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    %link{:crossorigin => "anonymous", :href => "https://use.fontawesome.com/releases/v5.7.0/css/all.css", :integrity => "sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ", :rel => "stylesheet"}/
   %body
     = yield


### PR DESCRIPTION
#WHAT
Fontawesome5を利用する為、レイアウトファイルにCDNを添付。

#WAY
Font-awesome-railsではfontawesome5を使用できず、他のgemでは本番環境に不具合を来すため。