### PR TITLE
カテゴリー一覧機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,4 @@
 @import "./modules/mercari/footer.scss";
 @import "./modules/mercari/second_header.scss";
 @import "./modules/mercari/second_footer.scss";
+@import "./modules/categories/index.scss";

--- a/app/assets/stylesheets/modules/categories/_index.scss
+++ b/app/assets/stylesheets/modules/categories/_index.scss
@@ -1,0 +1,76 @@
+.brand-index{
+  display: flex;
+  justify-content: center;
+  &__container {
+    width: 700px;
+    margin: 40px auto;
+    h2 {
+      padding: 8px 15px;
+      font-size: 22px;
+      line-height: 1.4;
+      font-weight: bold;
+    }
+    &__btns {
+      padding: 0 0 15px 5px;
+      display: flex;
+      flex-wrap: wrap;
+      &__btn {
+        font-size: 16px;
+        width: auto;
+        min-width: 30px;
+        line-height: 40px;
+        display: inline-block;
+        margin: 0 10px 10px 0;
+        padding: 0 30px;
+        border-radius: 4px;
+        border: thin solid white;
+        background-color: white;
+        color: black;
+        cursor: pointer;
+        box-shadow: 2px 2px 1px #DBDBDB;
+        text-decoration: none;
+      }
+    }
+    &__index {
+    }
+    &__list {
+      border-radius: 4px;
+      &__name {
+        color: $white-f;
+        height: 40px;
+        font-size: 22px;
+        background-color: $mercarired;
+        padding: 3px 30px 0 30px;
+        font-weight: bold;
+      }
+      &__box {
+        padding: 24px 20px 10px 30px;
+        background-color: white;
+        margin-bottom: 40px;
+        &__all {
+          @extend .lightblue-link-default-style;
+          text-decoration: none;
+          font-size: 16px;
+        }
+        &__label {
+          font-weight: bold;
+          margin-top: 15px;
+        }
+        &__categories {
+          padding: 0 20px 10px 20px;
+          display: flex;
+          flex-wrap: wrap;
+          &__category {
+            font-size: 16px;
+            width: 50%;
+            a {
+              margin: 6px 0;
+              @extend .lightblue-link-default-style;
+              display: inline-block;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,3 +1,6 @@
 class CategoriesController < ApplicationController
 
+  def index
+    @parents = Category.roots
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def get_child_from_root(root)
+    Category.children_of(root).all
+  end
+
+  def get_deeper_from_child(child)
+    Category.where("ancestry LIKE ?", "%/#{child.id}").all
+  end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,10 +1,2 @@
 module CategoriesHelper
-
-  def get_child_from_root(root)
-    Category.children_of(root).all
-  end
-
-  def get_deeper_from_child(child)
-    Category.where("ancestry LIKE ?", "%/#{child.id}").all
-  end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,2 +1,10 @@
 module CategoriesHelper
+
+  def get_child_from_root(root)
+    Category.children_of(root).all
+  end
+
+  def get_deeper_from_child(child)
+    Category.where("ancestry LIKE ?", "%/#{child.id}").all
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true  
+  self.abstract_class = true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,5 @@
 class Profile < ApplicationRecord
-  enum prefecture: [:hokkaido, :aomori, :iwate, :miyagi, :akita, :yamagata, :fukusima, :ibaragi, :tochigi, :gunma, :saitama, :chiba, :tokyo, :kanagawa, :nigata, :toyama, :isikawa, :fukui, :yamanashi, :nagano, :gifu, :sizuoka, :aichi, :mie,
-                    :siga, :kyoto, :osaka, :hyogo, :nara, :wakayama, :tottori, :simane, :okayama, :hiroshima, :yamaguchi, :tokusima, :kagawa, :ehime, :kouchi, :fukuoka, :saga, :nagasaki, :kumamoto, :oita, :miyazaki, :kagoshima, :okinawa]
+  enum prefecture: [:hokkaido, :aomori, :iwate, :miyagi, :akita, :yamagata, :fukusima, :ibaragi, :tochigi, :gunma, :saitama, :chiba, :tokyo, :kanagawa, :nigata, :toyama, :isikawa, :fukui, :yamanashi, :nagano, :gifu, :sizuoka, :aichi, :mie, :siga, :kyoto, :osaka, :hyogo, :nara, :wakayama, :tottori, :simane, :okayama, :hiroshima, :yamaguchi, :tokusima, :kagawa, :ehime, :kouchi, :fukuoka, :saga, :nagasaki, :kumamoto, :oita, :miyazaki, :kagoshima, :okinawa, :undecided]
   belongs_to :user
   validates :prefecture,      presence: true
   validates :phone,           presence: true, length: { minimum: 10, maximum: 16 },

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,0 +1,28 @@
+= render 'shared/header'
+.brand-index
+  .brand-index__container
+    %h2
+      カテゴリー一覧
+    .brand-index__container__btns
+      - @parents.each do |parent|
+        = link_to "", class: "brand-index__container__btns__btn" do
+          = parent.name
+    .brand-index__container__index
+    .brand-index__container__list
+    - @parents.each do |parent|
+      .brand-index__container__list__name
+        = parent.name
+      .brand-index__container__list__box
+        = link_to "", class: "brand-index__container__list__box__all" do
+          すべて
+        - get_child_from_root(parent).each do |child|
+          .brand-index__container__list__box__label
+            = child.name
+          .brand-index__container__list__box__categories
+            .brand-index__container__list__box__categories__category
+              = link_to "" do
+                すべて
+            - get_deeper_from_child(child).each do |grandchild|
+              .brand-index__container__list__box__categories__category
+                = link_to "" do
+                  =grandchild.name

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -15,8 +15,8 @@
         %ul.search-nav
           %li.search-nav__list
             %h2.search-nav__list__title
-              = link_to "https://www.mercari.com/jp/category/", class: "search-nav__list__title__link" do
-                カテゴリから探す
+              = link_to categories_path, class: "search-nav__list__title__link" do
+                カテゴリーから探す
           %li.search-nav__list
             %h2.search-nav__list__title
               = link_to "https://www.mercari.com/jp/category/", class: "search-nav__list__title__link" do


### PR DESCRIPTION
# What
#### Categoryテーブルに本家と同様の多階層カテゴリー構造をgem ancestryを用いて登録
#### カテゴリーの一覧表示用にビューを作成
#### 補足
- application_helperには多階層カテゴリーの検索メソッドを定義
- get_child_from_root()メソッド・・・最上位カテゴリー(root)から一層下(child)を全て取得
- get_deeper_from_child()メソッド・・・二層目以下のカテゴリーを起点にそのもう一つ下層の要素を全て取得
![categories](https://user-images.githubusercontent.com/46064552/52319813-ffbd1000-2a0e-11e9-9ee2-a6c5bbdb924c.gif)

# Why
#### ユーザーが欲しい商品をカテゴリーを元に絞り込めるようにし、ユーザビリティを向上するため