### PR TITLE
ポイント表示の編集

### DIFF
--- a/app/controllers/concerns/get_points.rb
+++ b/app/controllers/concerns/get_points.rb
@@ -5,6 +5,8 @@ module GetPoints
     if user_signed_in?
       points = PointRecord.where(user_id: current_user.id).all
       @points = points.sum { |p| p[:point] }
+    else
+      @points = 0
     end
   end
 end


### PR DESCRIPTION
# WHAT
ログインしていない場合のリターンの記述を追加しました

# WHY
商品詳細画面で、ログアウト時にもポイントの吹き出しが表示されていたため